### PR TITLE
Fix several typos in rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,4 +14,5 @@ Layout/LineLength:
 
 # We don't want to deepen nestings for classes
 Style/ClassAndModuleChildren:
-  Exclude: 'test/**/*'
+  Exclude:
+    - 'test/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+# We don't want to deepen nestings for classes
+Style/ClassAndModuleChildren:
+  Exclude: 'test/**/*'

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
 Bundler/GemVersion:
   Enabled: false
 
-# We usually have LISENCE file that describes cipyright information.
+# We usually have LICENSE file that describes copyright information.
 Style/Copyright:
   Enabled: false
 


### PR DESCRIPTION
This PR fix several typos in rubocop.yml

- s/LISENCE/LICENSE/
- s/cipyright/copyright/